### PR TITLE
TTP:21 Consistent filename case

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -76,7 +76,7 @@
             <div class="row">
                 <div class="col-md-4">
                     <div class="card mb-4 shadow-sm">
-                        <img src="{{ url_for('static', filename='images/thumbnails/t_dface-seattle.JPG') }}"
+                        <img src="{{ url_for('static', filename='images/thumbnails/t_dface-seattle.jpg') }}"
                             width="100%" height="100%" />
                         <title>D*Face, Seattle, 2018.</title>
                         <div class="card-body">


### PR DESCRIPTION
Mixed case on use of 'jpg' and 'JPG', amended all to lower case.