### PR TITLE
Added switch for Local/Prod Tests, fixed app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -3,17 +3,11 @@ instance_class: F1
 automatic_scaling:
     max_instances: 1
 
-libraries:
-- name: webapp2
-  version: latest
-- name: jinja2
-  version: latest
-
-  handlers:
+handlers:
 - url: /favicon\.ico
   static_files: favicon.ico
   upload: favicon\.ico
 
 - url: /bootstrap
   static_dir: bootstrap
-
+  

--- a/test/selenium/test_index.py
+++ b/test/selenium/test_index.py
@@ -11,6 +11,7 @@ Way too much repeated code...
 __version__ = 0.3
 
 import unittest
+import sys
 import datetime
 from time import time
 from selenium import webdriver
@@ -21,7 +22,9 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
-test_url = "http://127.0.0.1:8080/"
+local_test = "http://127.0.0.1:8080/"
+prod_test = "https://durable-sunspot-277600.appspot.com/"
+test_url = prod_test if sys.argv[1] == 'prod' else local_test
 debug_url = test_url + "?debug=true"
 
 
@@ -90,4 +93,4 @@ class TestsHomePage(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)

--- a/test/selenium/test_signup.py
+++ b/test/selenium/test_signup.py
@@ -9,6 +9,7 @@ remote executing script, logging, etc etc.
 
 __version__ = 0.3
 
+import sys
 import unittest
 import datetime
 from selenium import webdriver
@@ -19,10 +20,12 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import WebDriverWait
 from time import time
 
-test_url = "http://127.0.0.1:8080/info"
+local_test = "http://127.0.0.1:8080/info"
+prod_test = "https://durable-sunspot-277600.appspot.com/info"
+test_url = prod_test if sys.argv[1] == 'prod' else local_test
+
 debug_url = test_url + "?debug=true"
 start_time = datetime.datetime.now()
-
 
 class TestSignup(unittest.TestCase):
     def setUp(self):
@@ -68,8 +71,8 @@ class TestSignup(unittest.TestCase):
         time_span = tEnd - tStart
         print('Started', start_time)
         print(f'Test: {self} took {time_span} seconds duration')
-        self.driver.close()
+        driver.close()
 
 
 if __name__ == "__main__":
-    unittest.main()
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)


### PR DESCRIPTION
Added a switch to add test target as local or prod when run from command line. 'prod' targets the deployed URL, anything else runs locally. 

Also fixed up the not compatible with Python3 libraries tag in app.yaml, will repair correctly at some future point.