### PR TITLE
Fix code scanning alert no. 3: Flask app is run in debug mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -82,5 +82,6 @@ if __name__ == '__main__':
     # This is used when running locally only. When deploying to Google App
     # Engine, a webserver process such as Gunicorn will serve the app. This
     # can be configured by adding an `entrypoint` to app.yaml.
-    app.run(host='127.0.0.1', port=8080, debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(host='127.0.0.1', port=8080, debug=debug_mode)
 # [END gae_python38_app]


### PR DESCRIPTION
Fixes [https://github.com/simonhowlett/app-engine-ci/security/code-scanning/3](https://github.com/simonhowlett/app-engine-ci/security/code-scanning/3)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. This can be achieved by using an environment variable to control the debug mode. We will modify the `app.run` call to check the environment variable and enable debug mode only if it is explicitly set to `True`.

- Modify the `app.run` call to check an environment variable (e.g., `FLASK_DEBUG`) to determine whether to enable debug mode.
- Update the `app.run` line in `main.py` to use this environment variable.
- Ensure that the environment variable is set appropriately in the development environment and not set (or set to `False`) in the production environment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
